### PR TITLE
fixed campaign data leak during serialization

### DIFF
--- a/backend/src/OpenLoyalty/Bundle/CampaignBundle/Controller/Api/CampaignController.php
+++ b/backend/src/OpenLoyalty/Bundle/CampaignBundle/Controller/Api/CampaignController.php
@@ -8,6 +8,7 @@ namespace OpenLoyalty\Bundle\CampaignBundle\Controller\Api;
 use Broadway\CommandHandling\CommandBusInterface;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\Route;
+use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Controller\FOSRestController;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use OpenLoyalty\Bundle\CampaignBundle\Exception\CampaignLimitException;
@@ -55,6 +56,7 @@ class CampaignController extends FOSRestController
      * )
      *
      * @param Request $request
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -95,6 +97,7 @@ class CampaignController extends FOSRestController
      *
      * @param Request        $request
      * @param DomainCampaign $campaign
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -128,6 +131,7 @@ class CampaignController extends FOSRestController
      * )
      *
      * @param DomainCampaign $campaign
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -152,6 +156,7 @@ class CampaignController extends FOSRestController
      *
      * @param Request        $request
      * @param DomainCampaign $campaign
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return Response
      */
@@ -184,6 +189,7 @@ class CampaignController extends FOSRestController
      * )
      *
      * @param Request $request
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -221,6 +227,7 @@ class CampaignController extends FOSRestController
      *
      * @param DomainCampaign $campaign
      * @param                $active
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -251,6 +258,7 @@ class CampaignController extends FOSRestController
      * )
      *
      * @param Request $request
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -294,6 +302,7 @@ class CampaignController extends FOSRestController
      * )
      *
      * @param Request $request
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -337,6 +346,7 @@ class CampaignController extends FOSRestController
      * )
      *
      * @param DomainCampaign $campaign
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -357,6 +367,7 @@ class CampaignController extends FOSRestController
      *
      * @param Request        $request
      * @param DomainCampaign $campaign
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -397,6 +408,7 @@ class CampaignController extends FOSRestController
      *
      * @param Request         $request
      * @param CustomerDetails $customer
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -457,6 +469,7 @@ class CampaignController extends FOSRestController
      *
      * @param DomainCampaign  $campaign
      * @param CustomerDetails $customer
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -524,6 +537,7 @@ class CampaignController extends FOSRestController
      *
      * @param Request         $request
      * @param CustomerDetails $customer
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -582,6 +596,7 @@ class CampaignController extends FOSRestController
      * )
      *
      * @param Campaign $campaign
+     * @View(serializerGroups={"admin", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */

--- a/backend/src/OpenLoyalty/Bundle/CampaignBundle/Controller/Api/CustomerCampaignsController.php
+++ b/backend/src/OpenLoyalty/Bundle/CampaignBundle/Controller/Api/CustomerCampaignsController.php
@@ -8,6 +8,7 @@ namespace OpenLoyalty\Bundle\CampaignBundle\Controller\Api;
 use Broadway\CommandHandling\CommandBusInterface;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\Route;
+use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Controller\FOSRestController;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use OpenLoyalty\Bundle\CampaignBundle\Exception\CampaignLimitException;
@@ -47,6 +48,7 @@ class CustomerCampaignsController extends FOSRestController
      * )
      *
      * @param Request $request
+     * @View(serializerGroups={"customer", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -107,6 +109,7 @@ class CustomerCampaignsController extends FOSRestController
      * )
      *
      * @param Request $request
+     * @View(serializerGroups={"customer", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -164,6 +167,7 @@ class CustomerCampaignsController extends FOSRestController
      * )
      *
      * @param Campaign $campaign
+     * @View(serializerGroups={"customer", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */
@@ -232,6 +236,7 @@ class CustomerCampaignsController extends FOSRestController
      * )
      *
      * @param Campaign $campaign
+     * @View(serializerGroups={"customer", "Default"})
      *
      * @return \FOS\RestBundle\View\View
      */

--- a/backend/src/OpenLoyalty/Bundle/CampaignBundle/Event/Listener/CampaignSerializationListener.php
+++ b/backend/src/OpenLoyalty/Bundle/CampaignBundle/Event/Listener/CampaignSerializationListener.php
@@ -120,8 +120,10 @@ class CampaignSerializationListener implements EventSubscriberInterface
                 }
             }
 
-            $event->getVisitor()->addData('segmentNames', $segmentNames);
-            $event->getVisitor()->addData('levelNames', $levelNames);
+            if (in_array('admin', (array) $event->getContext()->attributes->get('groups'))) {
+                $event->getVisitor()->addData('segmentNames', $segmentNames);
+                $event->getVisitor()->addData('levelNames', $levelNames);
+            }
 
             if (!$this->campaignValidator->isCampaignActive($campaign)) {
                 if (!$campaign->getCampaignActivity()->isAllTimeActive()) {

--- a/backend/src/OpenLoyalty/Bundle/CampaignBundle/Resources/config/serializer/Campaign.yml
+++ b/backend/src/OpenLoyalty/Bundle/CampaignBundle/Resources/config/serializer/Campaign.yml
@@ -1,5 +1,4 @@
 OpenLoyalty\Domain\Campaign\Campaign:
-  exlusion_policy: ALL
   properties:
     campaignId:
       expose: true
@@ -20,9 +19,12 @@ OpenLoyalty\Domain\Campaign\Campaign:
     getFlatLevels:
         serialized_name: levels
         type: array
+        groups: ['admin']
     getFlatSegments:
         serialized_name: segments
         type: array
+        groups: ['admin']
     getFlatCoupons:
         serialized_name: coupons
         type: array
+        groups: ['admin']

--- a/backend/src/OpenLoyalty/Infrastructure/Audit/Persistance/Doctrine/Type/AuditLogIdDoctrineType.php
+++ b/backend/src/OpenLoyalty/Infrastructure/Audit/Persistance/Doctrine/Type/AuditLogIdDoctrineType.php
@@ -46,4 +46,14 @@ final class AuditLogIdDoctrineType extends UuidType
 
         return;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
 }

--- a/backend/src/OpenLoyalty/Infrastructure/Email/Persistance/Doctrine/Type/EmailIdDoctrineType.php
+++ b/backend/src/OpenLoyalty/Infrastructure/Email/Persistance/Doctrine/Type/EmailIdDoctrineType.php
@@ -47,4 +47,14 @@ class EmailIdDoctrineType extends UuidType
 
         return;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
 }


### PR DESCRIPTION
1) Added proper config for JMS serializer. Now only admin can see coupons, levels and segments of given campaign. Customer will not be able to see that data.

2) Fixed AuditLogIdDoctrineType and EmailIdDoctrineType, before each run of doctrine:schema:update command was executing a query.