### PR TITLE
Fixed wrong arguments count for constructor, deprecation warnings, unused imports and variables.

### DIFF
--- a/backend/src/OpenLoyalty/Bundle/UserBundle/Resources/config/services.yml
+++ b/backend/src/OpenLoyalty/Bundle/UserBundle/Resources/config/services.yml
@@ -108,7 +108,6 @@ services:
     arguments:
       - '@oloy.email.message_factory'
       - '@oloy.mailer'
-      - '%oloy.email.emails%'
       - {from_name: '%mailer_from_name%', from_address: '%mailer_from_address%', password_reset_url: '%frontend_password_reset_url%', loyalty_program_name: '%loyalty_program_name%', ecommerce_address: '%ecommerce_address%', customer_panel_url: '%frontend_customer_panel_url%'}
 
   oloy.user.es_param_manager:

--- a/backend/tests/OpenLoyalty/Bundle/BaseApiTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/BaseApiTest.php
@@ -2,14 +2,12 @@
 
 namespace OpenLoyalty\Bundle;
 
-use OpenLoyalty\Bundle\UserBundle\Controller\Api\CustomerControllerTest;
 use OpenLoyalty\Bundle\UserBundle\DataFixtures\ORM\LoadUserData;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 
 /**
- * Class BaseApiTest
- * @package OpenLoyaltyBundle\Controller\Api
+ * Class BaseApiTest.
  */
 abstract class BaseApiTest extends WebTestCase
 {
@@ -30,7 +28,7 @@ abstract class BaseApiTest extends WebTestCase
                 array(
                     '_username' => $username,
                     '_password' => $password,
-                )]));
+                ), ]));
         $this->assertTrue(isset($data['refresh_token']), 'Response should have field "refresh_token". '.$client->getResponse()->getContent());
 
         $client = static::createClient();
@@ -49,7 +47,7 @@ abstract class BaseApiTest extends WebTestCase
     {
         $client->request(
             'GET',
-            '/api/customer/' . $customerId . '/status'
+            '/api/customer/'.$customerId.'/status'
         );
         $response = $client->getResponse();
         $data = json_decode($response->getContent(), true);
@@ -84,6 +82,7 @@ abstract class BaseApiTest extends WebTestCase
     {
         $customer = static::$kernel->getContainer()->get('doctrine.orm.entity_manager')
             ->getRepository('OpenLoyaltyUserBundle:Customer')->findOneBy(['id' => $customerId]);
+
         return $customer;
     }
 }

--- a/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Controller/Api/CustomerCampaignsControllerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Controller/Api/CustomerCampaignsControllerTest.php
@@ -8,7 +8,6 @@ use OpenLoyalty\Bundle\UserBundle\DataFixtures\ORM\LoadUserData;
 use OpenLoyalty\Domain\Account\CustomerId;
 use OpenLoyalty\Domain\Account\ReadModel\AccountDetails;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetails;
-use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetailsRepository;
 
 /**
  * Class CustomerCampaignsControllerTest.
@@ -83,6 +82,7 @@ class CustomerCampaignsControllerTest extends BaseApiTest
         $customerDetails = $customerDetailsRepository->findBy(['email' => $email]);
         /** @var CustomerDetails $customerDetails */
         $customerDetails = reset($customerDetails);
+
         return $customerDetails;
     }
 }

--- a/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/DataTransformer/CouponsDataTransformerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/DataTransformer/CouponsDataTransformerTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenLoyalty\Bundle\CampaignBundle\Form\DataTransformer;
 
-use OpenLoyalty\Bundle\CampaignBundle\Form\DataTransformer\CouponsDataTransformer;
 use OpenLoyalty\Domain\Campaign\Model\Coupon;
 
 /**

--- a/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/DataTransformer/LevelsDataTransformerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/DataTransformer/LevelsDataTransformerTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenLoyalty\Bundle\CampaignBundle\Form\DataTransformer;
 
-use OpenLoyalty\Bundle\CampaignBundle\Form\DataTransformer\LevelsDataTransformer;
 use OpenLoyalty\Domain\Campaign\LevelId;
 
 /**

--- a/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/DataTransformer/SegmentsDataTransformerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/DataTransformer/SegmentsDataTransformerTest.php
@@ -2,7 +2,6 @@
 
 namespace OpenLoyalty\Bundle\CampaignBundle\Form\DataTransformer;
 
-use OpenLoyalty\Bundle\CampaignBundle\Form\DataTransformer\SegmentsDataTransformer;
 use OpenLoyalty\Domain\Campaign\SegmentId;
 
 /**

--- a/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/Type/CampaignFormTypeTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Form/Type/CampaignFormTypeTest.php
@@ -2,9 +2,6 @@
 
 namespace OpenLoyalty\Bundle\CampaignBundle\Form\Type;
 
-use OpenLoyalty\Bundle\CampaignBundle\Form\Type\CampaignActivityFormType;
-use OpenLoyalty\Bundle\CampaignBundle\Form\Type\CampaignFormType;
-use OpenLoyalty\Bundle\CampaignBundle\Form\Type\CampaignVisibilityFormType;
 use OpenLoyalty\Bundle\CampaignBundle\Model\Campaign;
 use OpenLoyalty\Bundle\LevelBundle\DataFixtures\ORM\LoadLevelData;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
@@ -21,9 +18,9 @@ class CampaignFormTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));

--- a/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Security/Voter/CampaignVoterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/CampaignBundle/Security/Voter/CampaignVoterTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\CampaignBundle\Security\Voter;
 
 use OpenLoyalty\Bundle\BaseVoterTest;
-use OpenLoyalty\Bundle\CampaignBundle\Security\Voter\CampaignVoter;
 use OpenLoyalty\Bundle\CampaignBundle\Service\CampaignProvider;
 use OpenLoyalty\Domain\Campaign\Campaign;
 use OpenLoyalty\Domain\Campaign\CampaignId;

--- a/backend/tests/OpenLoyalty/Bundle/EarningRuleBundle/Form/Type/CreateEarningRuleFormTypeTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/EarningRuleBundle/Form/Type/CreateEarningRuleFormTypeTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\EarningRuleBundle\Form\Type;
 
 use OpenLoyalty\Bundle\EarningRuleBundle\Model\EarningRule;
-use OpenLoyalty\Domain\Model\SKU;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -18,9 +17,9 @@ class CreateEarningRuleFormTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));

--- a/backend/tests/OpenLoyalty/Bundle/EarningRuleBundle/Form/Type/EditEarningRuleFormTypeTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/EarningRuleBundle/Form/Type/EditEarningRuleFormTypeTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\EarningRuleBundle\Form\Type;
 
 use OpenLoyalty\Bundle\EarningRuleBundle\Model\EarningRule;
-use OpenLoyalty\Domain\Model\SKU;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -18,9 +17,9 @@ class EditEarningRuleFormTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));

--- a/backend/tests/OpenLoyalty/Bundle/PointsBundle/Controller/Api/PointsTransferControllerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/PointsBundle/Controller/Api/PointsTransferControllerTest.php
@@ -40,7 +40,7 @@ class PointsTransferControllerTest extends BaseApiTest
             [
                 'transfer' => [
                     'customer' => LoadUserData::TEST_USER_ID,
-                    'points' => 100
+                    'points' => 100,
                 ],
             ]
         );
@@ -63,7 +63,7 @@ class PointsTransferControllerTest extends BaseApiTest
             [
                 'transfer' => [
                     'customer' => LoadUserData::TEST_USER_ID,
-                    'points' => 100
+                    'points' => 100,
                 ],
             ]
         );
@@ -86,13 +86,12 @@ class PointsTransferControllerTest extends BaseApiTest
             [
                 'transfer' => [
                     'customer' => LoadUserData::TEST_USER_ID,
-                    'points' => 10000
+                    'points' => 10000,
                 ],
             ]
         );
 
         $response = $client->getResponse();
-        $data = json_decode($response->getContent(), true);
         $this->assertEquals(400, $response->getStatusCode(), 'Response should have status 200');
     }
 

--- a/backend/tests/OpenLoyalty/Bundle/PointsBundle/Integration/AccountAggregateAndProjectionSyncTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/PointsBundle/Integration/AccountAggregateAndProjectionSyncTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\PointsBundle\Integration;
 
 use Broadway\ReadModel\RepositoryInterface;
-use OpenLoyalty\Bundle\PointsBundle\DataFixtures\ORM\LoadAccountsWithTransfersData;
 use OpenLoyalty\Bundle\UserBundle\DataFixtures\ORM\LoadUserData;
 use OpenLoyalty\Domain\Account\Account;
 use OpenLoyalty\Domain\Account\ReadModel\AccountDetails;
@@ -29,6 +28,8 @@ class AccountAggregateAndProjectionSyncTest extends KernelTestCase
     }
 
     /**
+     * @param int $customerId
+     * 
      * @return AccountDetails
      */
     protected function getAccountByCustomerId($customerId)

--- a/backend/tests/OpenLoyalty/Bundle/PointsBundle/Security/CustomerPointsTransferControllerAccessTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/PointsBundle/Security/CustomerPointsTransferControllerAccessTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\PointsBundle\Security;
 
 use OpenLoyalty\Bundle\BaseAccessControlTest;
-use OpenLoyalty\Bundle\PointsBundle\DataFixtures\ORM\LoadAccountsWithTransfersData;
 
 /**
  * Class CustomerPointsTransferControllerAccessTest.

--- a/backend/tests/OpenLoyalty/Bundle/PointsBundle/Service/CampaignValidatorTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/PointsBundle/Service/CampaignValidatorTest.php
@@ -107,7 +107,7 @@ class CampaignValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function getCouponUsageRepository($usage, $customerUsage)
     {
-        $repo = $this->getMock(CouponUsageRepository::class);
+        $repo = $this->getMockBuilder(CouponUsageRepository::class)->getMock();
         $repo->method('countUsageForCampaign')->with($this->isInstanceOf(CampaignId::class))
             ->willReturn($usage);
         $repo->method('countUsageForCampaignAndCustomer')->with(
@@ -120,7 +120,7 @@ class CampaignValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function getAccountDetailsRepository($points)
     {
-        $repo = $this->getMock(RepositoryInterface::class);
+        $repo = $this->getMockBuilder(RepositoryInterface::class)->getMock();
         $account = $this->getMockBuilder(AccountDetails::class)->disableOriginalConstructor()->getMock();
         $account->method('getAvailableAmount')->willReturn($points);
         $repo->method('findBy')->with($this->arrayHasKey('customerId'))

--- a/backend/tests/OpenLoyalty/Bundle/PosBundle/Form/Type/CreatePosFormTypeTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/PosBundle/Form/Type/CreatePosFormTypeTest.php
@@ -16,9 +16,9 @@ class CreatePosFormTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));

--- a/backend/tests/OpenLoyalty/Bundle/PosBundle/Form/Type/EditPosFormTypeTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/PosBundle/Form/Type/EditPosFormTypeTest.php
@@ -16,9 +16,9 @@ class EditPosFormTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));

--- a/backend/tests/OpenLoyalty/Bundle/SegmentBundle/Controller/Api/SegmentControllerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/SegmentBundle/Controller/Api/SegmentControllerTest.php
@@ -2,13 +2,11 @@
 
 namespace OpenLoyalty\Bundle\SegmentBundle\Controller\Api;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use OpenLoyalty\Bundle\BaseApiTest;
 use OpenLoyalty\Bundle\PosBundle\DataFixtures\ORM\LoadPosData;
 use OpenLoyalty\Bundle\SegmentBundle\DataFixtures\ORM\LoadSegmentData;
 use OpenLoyalty\Domain\Segment\Model\Criteria\Anniversary;
-use OpenLoyalty\Domain\Segment\Model\Criteria\BoughtInPos;
 use OpenLoyalty\Domain\Segment\Model\Criteria\TransactionCount;
 use OpenLoyalty\Domain\Segment\Model\Criterion;
 use OpenLoyalty\Domain\Segment\Segment;
@@ -43,7 +41,7 @@ class SegmentControllerTest extends BaseApiTest
             'POST',
             '/api/segment',
             [
-                'segment' =>  [
+                'segment' => [
                     'name' => 'test1234',
                     'description' => 'desc',
                     'parts' => [
@@ -63,7 +61,7 @@ class SegmentControllerTest extends BaseApiTest
                                     'min' => 10,
                                     'max' => 20,
                                 ],
-                            ]
+                            ],
                         ],
                     ],
                 ],
@@ -100,7 +98,7 @@ class SegmentControllerTest extends BaseApiTest
             'POST',
             '/api/segment',
             [
-                'segment' =>  [
+                'segment' => [
                     'name' => 'test2345',
                     'description' => 'desc',
                     'parts' => [
@@ -156,7 +154,7 @@ class SegmentControllerTest extends BaseApiTest
                                     'type' => Criterion::TYPE_BOUGHT_LABELS,
                                     'labels' => [[
                                         'key' => 'test',
-                                        'value' => 'label'
+                                        'value' => 'label',
                                     ]],
                                 ],
                             ],
@@ -196,7 +194,7 @@ class SegmentControllerTest extends BaseApiTest
             'PUT',
             '/api/segment/'.LoadSegmentData::SEGMENT_ID,
             [
-                'segment' =>  [
+                'segment' => [
                     'name' => 'test - updated',
                     'description' => 'desc',
                     'parts' => [
@@ -216,7 +214,7 @@ class SegmentControllerTest extends BaseApiTest
                                     'min' => 1,
                                     'max' => 100,
                                 ],
-                            ]
+                            ],
                         ],
                     ],
                 ],

--- a/backend/tests/OpenLoyalty/Bundle/SegmentBundle/Form/Type/SegmentFormTypeTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/SegmentBundle/Form/Type/SegmentFormTypeTest.php
@@ -6,9 +6,6 @@ use Broadway\UuidGenerator\UuidGeneratorInterface;
 use OpenLoyalty\Domain\Pos\Pos;
 use OpenLoyalty\Domain\Pos\PosId;
 use OpenLoyalty\Domain\Pos\PosRepository;
-use OpenLoyalty\Domain\Segment\Model\Criteria\AverageTransactionAmount;
-use OpenLoyalty\Domain\Segment\Model\Criteria\BoughtInPos;
-use OpenLoyalty\Domain\Segment\Model\Criteria\TransactionCount;
 use OpenLoyalty\Domain\Segment\Model\Criterion;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
@@ -28,9 +25,9 @@ class SegmentFormTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));
@@ -43,10 +40,10 @@ class SegmentFormTypeTest extends TypeTestCase
             $metadata
         );
 
-        $this->uuidGenerator = $this->getMock(UuidGeneratorInterface::class);
+        $this->uuidGenerator = $this->getMockBuilder(UuidGeneratorInterface::class)->getMock();
         $this->uuidGenerator->method('generate')->willReturn('00000000-0000-0000-0000-0000000000'.rand(10,99));
 
-        $this->posRepository = $this->getMock(PosRepository::class);
+        $this->posRepository = $this->getMockBuilder(PosRepository::class)->getMock();
         $this->posRepository->method('findAll')->will($this->returnCallback(function () {
             $pos = [];
             $pos[] = new Pos(new PosId('00000000-0000-0000-0000-000000000000'));
@@ -97,7 +94,7 @@ class SegmentFormTypeTest extends TypeTestCase
                             'min' => 10,
                             'max' => 20,
                         ],
-                    ]
+                    ],
                 ],
             ],
         ];

--- a/backend/tests/OpenLoyalty/Bundle/SettingsBundle/Form/Type/SettingsFormTypeTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/SettingsBundle/Form/Type/SettingsFormTypeTest.php
@@ -9,6 +9,7 @@ use OpenLoyalty\Bundle\SettingsBundle\Entity\StringSettingEntry;
 use OpenLoyalty\Bundle\SettingsBundle\Model\Settings;
 use OpenLoyalty\Bundle\SettingsBundle\Model\TranslationsEntry;
 use OpenLoyalty\Bundle\SettingsBundle\Service\TranslationsProvider;
+use OpenLoyalty\Bundle\SettingsBundle\Service\SettingsManager;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -60,11 +61,11 @@ class SettingsFormTypeTest extends TypeTestCase
             new TranslationsEntry('english.json'),
         ]);
 
-        $this->settingsManager = $this->getMock('OpenLoyalty\Bundle\SettingsBundle\Service\SettingsManager');
+        $this->settingsManager = $this->getMockBuilder(SettingsManager::class)->getMock();
         $this->settingsManager->method('getSettingByKey')->willReturn(null);
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));
@@ -141,13 +142,13 @@ class SettingsFormTypeTest extends TypeTestCase
                 ['field' => 'email', 'priority' => 1],
             ],
             'excludedDeliverySKUs' => [
-                '123'
+                '123',
             ],
             'excludedLevelSKUs' => [
-                '123'
+                '123',
             ],
             'excludedLevelCategories' => [
-                '123'
+                '123',
             ],
         ]);
 

--- a/backend/tests/OpenLoyalty/Bundle/Transaction/Controller/Api/TransactionControllerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/Transaction/Controller/Api/TransactionControllerTest.php
@@ -5,11 +5,11 @@ namespace OpenLoyalty\Bundle\Transaction\Controller\Api;
 use OpenLoyalty\Bundle\BaseApiTest;
 use OpenLoyalty\Bundle\PosBundle\DataFixtures\ORM\LoadPosData;
 use OpenLoyalty\Bundle\SettingsBundle\Entity\JsonSettingEntry;
-use OpenLoyalty\Bundle\TransactionBundle\DataFixtures\ORM\LoadTransactionData;
 use OpenLoyalty\Bundle\UserBundle\DataFixtures\ORM\LoadUserData;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetails;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetailsRepository;
 use OpenLoyalty\Domain\Transaction\ReadModel\TransactionDetails;
+use OpenLoyalty\Bundle\SettingsBundle\Service\SettingsManager;
 
 /**
  * Class TransactionControllerTest.
@@ -362,11 +362,10 @@ class TransactionControllerTest extends BaseApiTest
         /** @var CustomerDetailsRepository $customerRepo */
         $customerRepo = static::$kernel->getContainer()->get('oloy.user.read_model.repository.customer_details');
         /** @var CustomerDetails $customer */
-        $customer = $customerRepo-> findOneByCriteria(['email' => 'user@oloy.com'], 1);
+        $customer = $customerRepo->findOneByCriteria(['email' => 'user@oloy.com'], 1);
         $customer = reset($customer);
         $transactionsCount = $customer->getTransactionsCount();
         $transactionsAmount = $customer->getTransactionsAmount();
-        $transactionAvg = $customer->getAverageTransactionAmount();
 
         $formData = [
             'revisedDocument' => '456',
@@ -430,12 +429,11 @@ class TransactionControllerTest extends BaseApiTest
         $this->assertInstanceOf(TransactionDetails::class, $transaction);
         $this->assertNotNull($transaction->getCustomerId());
         /** @var CustomerDetails $customer */
-        $customer = $customerRepo-> findOneByCriteria(['email' => 'user@oloy.com'], 1);
+        $customer = $customerRepo->findOneByCriteria(['email' => 'user@oloy.com'], 1);
         $customer = reset($customer);
         $newTransactionsCount = $customer->getTransactionsCount();
         $newTransactionsAmount = $customer->getTransactionsAmount();
-        $newTransactionAvg = $customer->getAverageTransactionAmount();
-        $this->assertEquals($transactionsCount-1, $newTransactionsCount);
+        $this->assertEquals($transactionsCount - 1, $newTransactionsCount);
         $this->assertEquals($transactionsAmount - 3, $newTransactionsAmount);
     }
 
@@ -448,11 +446,10 @@ class TransactionControllerTest extends BaseApiTest
         /** @var CustomerDetailsRepository $customerRepo */
         $customerRepo = static::$kernel->getContainer()->get('oloy.user.read_model.repository.customer_details');
         /** @var CustomerDetails $customer */
-        $customer = $customerRepo-> findOneByCriteria(['email' => 'user-temp@oloy.com'], 1);
+        $customer = $customerRepo->findOneByCriteria(['email' => 'user-temp@oloy.com'], 1);
         $customer = reset($customer);
         $transactionsCount = $customer->getTransactionsCount();
         $transactionsAmount = $customer->getTransactionsAmount();
-        $transactionAvg = $customer->getAverageTransactionAmount();
 
         $formData = [
             'revisedDocument' => '789',
@@ -508,11 +505,10 @@ class TransactionControllerTest extends BaseApiTest
         $this->assertInstanceOf(TransactionDetails::class, $transaction);
         $this->assertNotNull($transaction->getCustomerId());
         /** @var CustomerDetails $customer */
-        $customer = $customerRepo-> findOneByCriteria(['email' => 'user-temp@oloy.com'], 1);
+        $customer = $customerRepo->findOneByCriteria(['email' => 'user-temp@oloy.com'], 1);
         $customer = reset($customer);
         $newTransactionsCount = $customer->getTransactionsCount();
         $newTransactionsAmount = $customer->getTransactionsAmount();
-        $newTransactionAvg = $customer->getAverageTransactionAmount();
         $this->assertEquals($transactionsCount, $newTransactionsCount);
         $this->assertEquals($transactionsAmount - 1, $newTransactionsAmount);
     }
@@ -523,7 +519,7 @@ class TransactionControllerTest extends BaseApiTest
     public function it_register_new_transaction_and_assign_customer_by_loyalty_card()
     {
         static::$kernel->boot();
-        $settingsManager = $this->getMock('OpenLoyalty\Bundle\SettingsBundle\Service\SettingsManager');
+        $settingsManager = $this->getMockBuilder(SettingsManager::class)->getMock();
         $settingsManager->method('getSettingByKey')->with($this->isType('string'))->will(
             $this->returnCallback(function ($arg) {
                 if ($arg == 'customersIdentificationPriority') {

--- a/backend/tests/OpenLoyalty/Bundle/Transaction/Form/Type/TransactionFormTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/Transaction/Form/Type/TransactionFormTest.php
@@ -3,13 +3,10 @@
 namespace OpenLoyalty\Bundle\Transaction\Form\Type;
 
 use OpenLoyalty\Bundle\PosBundle\DataFixtures\ORM\LoadPosData;
-use OpenLoyalty\Bundle\TransactionBundle\Form\Type\CustomerDetailsFormType;
 use OpenLoyalty\Bundle\TransactionBundle\Form\Type\TransactionFormType;
-use OpenLoyalty\Bundle\UserBundle\DataFixtures\ORM\LoadUserData;
-use OpenLoyalty\Domain\Customer\CustomerId;
-use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetails;
 use OpenLoyalty\Domain\Pos\Pos;
 use OpenLoyalty\Domain\Pos\PosId;
+use OpenLoyalty\Domain\Pos\PosRepository;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -26,9 +23,9 @@ class TransactionFormTest extends TypeTestCase
 
     protected function setUp()
     {
-        $this->validator = $this->getMock(
+        $this->validator = $this->getMockBuilder(
             'Symfony\Component\Validator\Validator\ValidatorInterface'
-        );
+        )->getMock();
         $this->validator
             ->method('validate')
             ->will($this->returnValue(new ConstraintViolationList()));
@@ -41,7 +38,7 @@ class TransactionFormTest extends TypeTestCase
             $metadata
         );
 
-        $this->posRepo = $this->getMock('OpenLoyalty\Domain\Pos\PosRepository');
+        $this->posRepo = $this->getMockBuilder(PosRepository::class)->getMock();
         $this->posRepo->method('findAll')
             ->willReturn([new Pos(new PosId(LoadPosData::POS_ID))]);
 
@@ -119,5 +116,4 @@ class TransactionFormTest extends TypeTestCase
             $this->assertArrayHasKey($key, $children);
         }
     }
-
 }

--- a/backend/tests/OpenLoyalty/Bundle/Transaction/Security/Voter/TransactionVoterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/Transaction/Security/Voter/TransactionVoterTest.php
@@ -32,7 +32,7 @@ class TransactionVoterTest extends BaseVoterTest
             TransactionVoter::ASSIGN_CUSTOMER_TO_TRANSACTION => ['seller' => true, 'customer' => false, 'admin' => true, 'id' => LoadTransactionData::TRANSACTION_ID],
             TransactionVoter::LIST_ITEM_LABELS => ['seller' => true, 'customer' => true, 'admin' => true],
         ];
-        $repo = $this->getMock(SellerDetailsRepository::class);
+        $repo = $this->getMockBuilder(SellerDetailsRepository::class)->getMock();
         $repo->method('find')->with($this->isType('string'))->willReturn(null);
         $voter = new TransactionVoter($repo);
 

--- a/backend/tests/OpenLoyalty/Bundle/UserBundle/Controller/Api/CustomerControllerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/UserBundle/Controller/Api/CustomerControllerTest.php
@@ -9,8 +9,7 @@ use OpenLoyalty\Domain\Customer\Command\CustomerCommandHandlerTest;
 use OpenLoyalty\Domain\Customer\PosId;
 
 /**
- * Class CustomerControllerTest
- * @package OpenLoyalty\Bundle\UserBundle\Controller\Api
+ * Class CustomerControllerTest.
  */
 class CustomerControllerTest extends BaseApiTest
 {
@@ -36,12 +35,12 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
                     'agreement1' => true,
                     'agreement2' => true,
                     'loyaltyCardNumber' => '0000000011',
-                ]
+                ],
             ]
         );
 
@@ -75,11 +74,11 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
                     'agreement1' => true,
                     'agreement2' => true,
-                ]
+                ],
             ]
         );
 
@@ -113,12 +112,12 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
                     'agreement1' => true,
                     'agreement2' => true,
                     'plainPassword' => 'OpenLoyalty123!',
-                ]
+                ],
             ]
         );
 
@@ -149,7 +148,7 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                     ],
-                ]
+                ],
             ]
         );
 
@@ -182,10 +181,10 @@ class CustomerControllerTest extends BaseApiTest
                         'address1' => '12',
                         'postal' => '00-800',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
-                    'loyaltyCardNumber' => '0000000011'
-                ]
+                    'loyaltyCardNumber' => '0000000011',
+                ],
             ]
         );
 
@@ -208,7 +207,7 @@ class CustomerControllerTest extends BaseApiTest
                     'lastName' => 'Doe',
                     'email' => 'john2@doe.com',
                     'agreement1' => true,
-                ]
+                ],
             ]
         );
 
@@ -242,10 +241,10 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
-                    'loyaltyCardNumber' => '000000000'
-                ]
+                    'loyaltyCardNumber' => '000000000',
+                ],
             ]
         );
 
@@ -276,10 +275,10 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
-                    'loyaltyCardNumber' => '0000000011'
-                ]
+                    'loyaltyCardNumber' => '0000000011',
+                ],
             ]
         );
 
@@ -310,11 +309,11 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
                     'phone' => '11111',
-                    'loyaltyCardNumber' => '0000000011'
-                ]
+                    'loyaltyCardNumber' => '0000000011',
+                ],
             ]
         );
 
@@ -340,13 +339,12 @@ class CustomerControllerTest extends BaseApiTest
             'PUT',
             '/api/customer/'.LoadUserData::TEST_USER_ID,
             [
-                'customer' => $customerData
+                'customer' => $customerData,
             ]
         );
 
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
-
 
         self::$kernel->boot();
 
@@ -380,13 +378,12 @@ class CustomerControllerTest extends BaseApiTest
             'PUT',
             '/api/customer/'.LoadUserData::TEST_USER_ID,
             [
-                'customer' => $customerData
+                'customer' => $customerData,
             ]
         );
 
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
-
 
         self::$kernel->boot();
 
@@ -437,7 +434,6 @@ class CustomerControllerTest extends BaseApiTest
         );
 
         $response = $client->getResponse();
-        $data = json_decode($response->getContent(), true);
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
     }
 
@@ -478,7 +474,6 @@ class CustomerControllerTest extends BaseApiTest
         $this->assertEquals('user@oloy.com', $data['customers'][0]['email']);
     }
 
-
     /**
      * @test
      */
@@ -497,7 +492,6 @@ class CustomerControllerTest extends BaseApiTest
 
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
-
 
         self::$kernel->boot();
 
@@ -529,8 +523,8 @@ class CustomerControllerTest extends BaseApiTest
                     'lastName' => 'Doe',
                     'email' => 'johhhn@doe.com',
                     'agreement1' => true,
-                    'referral_customer_email' => 'referral_customer_mail@test.com'
-                ]
+                    'referral_customer_email' => 'referral_customer_mail@test.com',
+                ],
             ]
         );
 
@@ -538,44 +532,44 @@ class CustomerControllerTest extends BaseApiTest
         $this->assertEquals(400, $response->getStatusCode(), 'Response should have status 400');
 
         $expectedResponseArray = [
-            "form" => [
-                "children" => [
-                    "firstName" => [],
-                    "lastName" => [],
-                    "gender" => [],
-                    "email" => [],
-                    "phone" => [],
-                    "birthDate" => [],
-                    "createdAt" => [],
-                    "address" => [
-                        "children" => [
-                            "street" => [],
-                            "address1" => [],
-                            "address2" => [],
-                            "postal" => [],
-                            "city" => [],
-                            "province" => [],
-                            "country" => []
-                        ]
-                    ],
-                    "company" =>[
-                        "children" => [
-                            "name" => [],
-                            "nip" => []
+            'form' => [
+                'children' => [
+                    'firstName' => [],
+                    'lastName' => [],
+                    'gender' => [],
+                    'email' => [],
+                    'phone' => [],
+                    'birthDate' => [],
+                    'createdAt' => [],
+                    'address' => [
+                        'children' => [
+                            'street' => [],
+                            'address1' => [],
+                            'address2' => [],
+                            'postal' => [],
+                            'city' => [],
+                            'province' => [],
+                            'country' => [],
                         ],
                     ],
-                    "loyaltyCardNumber" => [],
-                    "agreement1" => [],
-                    "agreement2" => [],
-                    "agreement3" => [],
-                    "referral_customer_email" => [
-                        "errors" => ["Referral customer email doesn't exist"]
+                    'company' => [
+                        'children' => [
+                            'name' => [],
+                            'nip' => [],
+                        ],
                     ],
-                    "levelId" => [],
-                    "posId" => [],
+                    'loyaltyCardNumber' => [],
+                    'agreement1' => [],
+                    'agreement2' => [],
+                    'agreement3' => [],
+                    'referral_customer_email' => [
+                        'errors' => ["Referral customer email doesn't exist"],
+                    ],
+                    'levelId' => [],
+                    'posId' => [],
                 ],
             ],
-          "errors" => [],
+          'errors' => [],
         ];
 
         $data = json_decode($response->getContent(), true);
@@ -592,7 +586,7 @@ class CustomerControllerTest extends BaseApiTest
         /** Get referral customer points*/
         $points = $this->getCustomerPoints($client, LoadUserData::USER_USER_ID);
 
-        /** Create new customer with referral email */
+        /* Create new customer with referral email */
         $client->request(
             'POST',
             '/api/customer/register',
@@ -602,8 +596,8 @@ class CustomerControllerTest extends BaseApiTest
                     'lastName' => 'Doe',
                     'email' => 'johhhn@doe.com',
                     'agreement1' => true,
-                    'referral_customer_email' => LoadUserData::USER_USERNAME
-                ]
+                    'referral_customer_email' => LoadUserData::USER_USERNAME,
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -623,7 +617,7 @@ class CustomerControllerTest extends BaseApiTest
     {
         $client = $this->createAuthenticatedClient();
 
-        /** Create new customer with referral email */
+        /* Create new customer with referral email */
         $client->request(
             'POST',
             '/api/customer/register',
@@ -633,8 +627,8 @@ class CustomerControllerTest extends BaseApiTest
                     'lastName' => 'Doe',
                     'email' => 'johhhnn@doe.com',
                     'agreement1' => true,
-                    'referral_customer_email' => ''
-                ]
+                    'referral_customer_email' => '',
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -664,13 +658,13 @@ class CustomerControllerTest extends BaseApiTest
                         'postal' => '00-800',
                         'city' => 'Warszawa',
                         'country' => 'PL',
-                        'province' => 'mazowieckie'
+                        'province' => 'mazowieckie',
                     ],
                     'agreement1' => true,
                     'agreement2' => true,
                     'plainPassword' => 'OpenLoyalty123!',
-                    'referral_customer_email' => 'wrong@test.email.com'
-                ]
+                    'referral_customer_email' => 'wrong@test.email.com',
+                ],
             ]
         );
 
@@ -678,43 +672,43 @@ class CustomerControllerTest extends BaseApiTest
         $this->assertEquals(400, $response->getStatusCode(), 'Response should have status 400');
 
         $expectedResponseArray = [
-            "form" => [
-                "children" => [
-                    "firstName" => [],
-                    "lastName" => [],
-                    "gender" => [],
-                    "email" => [],
-                    "phone" => [],
-                    "birthDate" => [],
-                    "createdAt" => [],
-                    "address" => [
-                        "children" => [
-                            "street" => [],
-                            "address1" => [],
-                            "address2" => [],
-                            "postal" => [],
-                            "city" => [],
-                            "province" => [],
-                            "country" => []
-                        ]
-                    ],
-                    "company" =>[
-                        "children" => [
-                            "name" => [],
-                            "nip" => []
+            'form' => [
+                'children' => [
+                    'firstName' => [],
+                    'lastName' => [],
+                    'gender' => [],
+                    'email' => [],
+                    'phone' => [],
+                    'birthDate' => [],
+                    'createdAt' => [],
+                    'address' => [
+                        'children' => [
+                            'street' => [],
+                            'address1' => [],
+                            'address2' => [],
+                            'postal' => [],
+                            'city' => [],
+                            'province' => [],
+                            'country' => [],
                         ],
                     ],
-                    "loyaltyCardNumber" => [],
-                    "agreement1" => [],
-                    "agreement2" => [],
-                    "agreement3" => [],
-                    "referral_customer_email" => [
-                        "errors" => ["Referral customer email doesn't exist"]
+                    'company' => [
+                        'children' => [
+                            'name' => [],
+                            'nip' => [],
+                        ],
                     ],
-                    "plainPassword" => [],
+                    'loyaltyCardNumber' => [],
+                    'agreement1' => [],
+                    'agreement2' => [],
+                    'agreement3' => [],
+                    'referral_customer_email' => [
+                        'errors' => ["Referral customer email doesn't exist"],
+                    ],
+                    'plainPassword' => [],
                 ],
             ],
-            "errors" => [],
+            'errors' => [],
         ];
 
         $data = json_decode($response->getContent(), true);
@@ -728,7 +722,7 @@ class CustomerControllerTest extends BaseApiTest
     {
         $client = $this->createAuthenticatedClient();
 
-        /** Create new customer with referral email */
+        /* Create new customer with referral email */
         $client->request(
             'POST',
             '/api/customer/self_register',
@@ -739,8 +733,8 @@ class CustomerControllerTest extends BaseApiTest
                     'email' => 'self_register@doe.com',
                     'agreement1' => true,
                     'plainPassword' => 'OpenLoyalty123!',
-                    'referral_customer_email' => LoadUserData::USER_USERNAME
-                ]
+                    'referral_customer_email' => LoadUserData::USER_USERNAME,
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -754,7 +748,7 @@ class CustomerControllerTest extends BaseApiTest
     {
         $client = $this->createAuthenticatedClient();
 
-        /** Create new customer with referral email */
+        /* Create new customer with referral email */
         $client->request(
             'POST',
             '/api/customer/self_register',
@@ -765,8 +759,8 @@ class CustomerControllerTest extends BaseApiTest
                     'email' => 'self_register2@doe.com',
                     'agreement1' => true,
                     'plainPassword' => 'OpenLoyalty123!',
-                    'referral_customer_email' => ''
-                ]
+                    'referral_customer_email' => '',
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -791,7 +785,7 @@ class CustomerControllerTest extends BaseApiTest
 
         $client->request(
             'POST',
-            '/api/customer/activate/' . $activateToken
+            '/api/customer/activate/'.$activateToken
         );
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
@@ -809,7 +803,7 @@ class CustomerControllerTest extends BaseApiTest
     {
         $client = $this->createAuthenticatedClient();
 
-        /** Create new customer with marketing agreement */
+        /* Create new customer with marketing agreement */
         $client->request(
             'POST',
             '/api/customer/register',
@@ -819,8 +813,8 @@ class CustomerControllerTest extends BaseApiTest
                     'lastName' => 'Doe',
                     'email' => 'marketing@doe.com',
                     'agreement1' => true,
-                    'agreement2' => true
-                ]
+                    'agreement2' => true,
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -843,7 +837,7 @@ class CustomerControllerTest extends BaseApiTest
         $client = $this->createAuthenticatedClient();
         $customerEmail = 'marketing_self@doe.com';
 
-        /** Create new customer with marketing agreement */
+        /* Create new customer with marketing agreement */
         $client->request(
             'POST',
             '/api/customer/self_register',
@@ -854,8 +848,8 @@ class CustomerControllerTest extends BaseApiTest
                     'email' => $customerEmail,
                     'agreement1' => true,
                     'agreement2' => true,
-                    'plainPassword' => 'OpenLoyalty123!'
-                ]
+                    'plainPassword' => 'OpenLoyalty123!',
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -873,7 +867,7 @@ class CustomerControllerTest extends BaseApiTest
         $activateToken = $this->getActivateTokenForCustomer($customerEmail);
         $client->request(
             'POST',
-            '/api/customer/activate/' . $activateToken
+            '/api/customer/activate/'.$activateToken
         );
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
@@ -899,7 +893,7 @@ class CustomerControllerTest extends BaseApiTest
         //Update customer data with checked agreement2
         $client->request(
             'GET',
-            '/api/customer/' . $customerId
+            '/api/customer/'.$customerId
         );
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
@@ -912,15 +906,15 @@ class CustomerControllerTest extends BaseApiTest
 
         $client->request(
             'PUT',
-            '/api/customer/' . $customerId,
+            '/api/customer/'.$customerId,
             [
                 'customer' => [
-                    'firstName'     => $customerData['firstName'],
-                    'lastName'      => $customerData['lastName'],
-                    'email'         => $customerData['email'],
-                    'agreement1'    => true,
-                    'agreement2'    => true,
-                ]
+                    'firstName' => $customerData['firstName'],
+                    'lastName' => $customerData['lastName'],
+                    'email' => $customerData['email'],
+                    'agreement1' => true,
+                    'agreement2' => true,
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -948,7 +942,7 @@ class CustomerControllerTest extends BaseApiTest
         //Update customer data with checked agreement2
         $client->request(
             'GET',
-            '/api/customer/' . $customerId
+            '/api/customer/'.$customerId
         );
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
@@ -957,15 +951,15 @@ class CustomerControllerTest extends BaseApiTest
 
         $client->request(
             'PUT',
-            '/api/customer/' . $customerId,
+            '/api/customer/'.$customerId,
             [
                 'customer' => [
-                    'firstName'     => $customerData['firstName'],
-                    'lastName'      => $customerData['lastName'],
-                    'email'         => $customerData['email'],
-                    'agreement1'    => true,
-                    'agreement2'    => false,
-                ]
+                    'firstName' => $customerData['firstName'],
+                    'lastName' => $customerData['lastName'],
+                    'email' => $customerData['email'],
+                    'agreement1' => true,
+                    'agreement2' => false,
+                ],
             ]
         );
         $response = $client->getResponse();
@@ -996,7 +990,7 @@ class CustomerControllerTest extends BaseApiTest
         //Update customer data with checked agreement2
         $client->request(
             'GET',
-            '/api/customer/' . $customerId
+            '/api/customer/'.$customerId
         );
         $response = $client->getResponse();
         $this->assertEquals(200, $response->getStatusCode(), 'Response should have status 200');
@@ -1005,15 +999,15 @@ class CustomerControllerTest extends BaseApiTest
 
         $client->request(
             'PUT',
-            '/api/customer/' . $customerId,
+            '/api/customer/'.$customerId,
             [
                 'customer' => [
-                    'firstName'     => $customerData['firstName'],
-                    'lastName'      => $customerData['lastName'],
-                    'email'         => $customerData['email'],
-                    'agreement1'    => true,
-                    'agreement2'    => true,
-                ]
+                    'firstName' => $customerData['firstName'],
+                    'lastName' => $customerData['lastName'],
+                    'email' => $customerData['email'],
+                    'agreement1' => true,
+                    'agreement2' => true,
+                ],
             ]
         );
         $response = $client->getResponse();

--- a/backend/tests/OpenLoyalty/Bundle/UserBundle/Controller/Api/SellerControllerTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/UserBundle/Controller/Api/SellerControllerTest.php
@@ -30,7 +30,7 @@ class SellerControllerTest extends BaseApiTest
                     'phone' => '0000000011',
                     'posId' => LoadPosData::POS_ID,
                     'plainPassword' => 'oloy',
-                ]
+                ],
             ]
         );
 
@@ -60,12 +60,11 @@ class SellerControllerTest extends BaseApiTest
                     'phone' => '0000000011',
                     'posId' => LoadPosData::POS_ID,
                     'plainPassword' => 'oloy',
-                ]
+                ],
             ]
         );
 
         $response = $client->getResponse();
-        $data = json_decode($response->getContent(), true);
         $this->assertEquals(400, $response->getStatusCode(), 'Response should have status 400');
     }
 
@@ -86,7 +85,7 @@ class SellerControllerTest extends BaseApiTest
                     'email' => 'john@doe.com',
                     'phone' => '0000000011',
                     'posId' => LoadPosData::POS_ID,
-                ]
+                ],
             ]
         );
 

--- a/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/RefreshTokenTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/RefreshTokenTest.php
@@ -6,8 +6,7 @@ use OpenLoyalty\Bundle\BaseApiTest;
 use OpenLoyalty\Bundle\UserBundle\DataFixtures\ORM\LoadUserData;
 
 /**
- * Class RefreshTokenTest
- * @package OpenLoyalty\Bundle\UserBundle\Security
+ * Class RefreshTokenTest.
  */
 class RefreshTokenTest extends BaseApiTest
 {
@@ -32,13 +31,13 @@ class RefreshTokenTest extends BaseApiTest
         $refreshToken = $data['refresh_token'];
 
         $client = static::createClient();
-        $client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $data['token']));
+        $client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $token));
 
         $client->request(
             'POST',
             '/api/token/refresh',
             [
-                'refresh_token' => $refreshToken
+                'refresh_token' => $refreshToken,
             ]
         );
 

--- a/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/CustomerSearchVoterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/CustomerSearchVoterTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\UserBundle\Security\Voter;
 
 use OpenLoyalty\Bundle\BaseVoterTest;
-use OpenLoyalty\Bundle\UserBundle\Security\Voter\CustomerSearchVoter;
 
 /**
  * Class CustomerSearchVoterTest.

--- a/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/CustomerVoterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/CustomerVoterTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\UserBundle\Security\Voter;
 
 use OpenLoyalty\Bundle\BaseVoterTest;
-use OpenLoyalty\Bundle\UserBundle\Security\Voter\CustomerVoter;
 use OpenLoyalty\Domain\Customer\CustomerId;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetails;
 use OpenLoyalty\Domain\Seller\ReadModel\SellerDetailsRepository;
@@ -34,7 +33,7 @@ class CustomerVoterTest extends BaseVoterTest
             CustomerVoter::EDIT => ['seller' => true, 'customer' => false, 'admin' => true, 'id' => self::CUSTOMER_ID],
         ];
 
-        $repo = $this->getMock(SellerDetailsRepository::class);
+        $repo = $this->getMockBuilder(SellerDetailsRepository::class)->getMock();
         $repo->method('find')->willReturn(null);
 
         $voter = new CustomerVoter($repo);

--- a/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/SellerVoterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/SellerVoterTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\UserBundle\Security\Voter;
 
 use OpenLoyalty\Bundle\BaseVoterTest;
-use OpenLoyalty\Bundle\UserBundle\Security\Voter\SellerVoter;
 use OpenLoyalty\Domain\Seller\ReadModel\SellerDetails;
 use OpenLoyalty\Domain\Seller\SellerId;
 

--- a/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/UserVoterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/UserBundle/Security/Voter/UserVoterTest.php
@@ -3,7 +3,6 @@
 namespace OpenLoyalty\Bundle\UserBundle\Security\Voter;
 
 use OpenLoyalty\Bundle\BaseVoterTest;
-use OpenLoyalty\Bundle\UserBundle\Security\Voter\UserVoter;
 
 /**
  * Class UserVoterTest.

--- a/backend/tests/OpenLoyalty/Bundle/Utility/Security/Voter/UtilityVoterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/Utility/Security/Voter/UtilityVoterTest.php
@@ -3,13 +3,7 @@
 namespace OpenLoyalty\Bundle\Transaction\Security\Voter;
 
 use OpenLoyalty\Bundle\BaseVoterTest;
-use OpenLoyalty\Bundle\TransactionBundle\DataFixtures\ORM\LoadTransactionData;
-use OpenLoyalty\Bundle\TransactionBundle\Security\Voter\TransactionVoter;
 use OpenLoyalty\Bundle\UtilityBundle\Security\Voter\UtilityVoter;
-use OpenLoyalty\Domain\Customer\CustomerId;
-use OpenLoyalty\Domain\Seller\ReadModel\SellerDetailsRepository;
-use OpenLoyalty\Domain\Transaction\ReadModel\TransactionDetails;
-use OpenLoyalty\Domain\Transaction\TransactionId;
 
 /**
  * Class TransactionVoterTest.
@@ -30,8 +24,8 @@ class UtilityVoterTest extends BaseVoterTest
         $voter = new UtilityVoter();
 
         $this->makeAssertions($attributes, $voter);
-
     }
+
     protected function getSubjectById($id)
     {
         return null;

--- a/backend/tests/OpenLoyalty/Bundle/Utility/Service/CustomerDetailsCsvFormatterTest.php
+++ b/backend/tests/OpenLoyalty/Bundle/Utility/Service/CustomerDetailsCsvFormatterTest.php
@@ -3,21 +3,13 @@
 namespace OpenLoyalty\Bundle\UtilityBundle\Service;
 
 use Broadway\ReadModel\RepositoryInterface;
-use OpenLoyalty\Bundle\CampaignBundle\Service\CampaignValidator;
 use OpenLoyalty\Domain\Account\Account;
-use OpenLoyalty\Domain\Account\ReadModel\AccountDetails;
-use OpenLoyalty\Domain\Campaign\Campaign;
-use OpenLoyalty\Domain\Campaign\CampaignId;
 use OpenLoyalty\Domain\Campaign\CustomerId;
-use OpenLoyalty\Domain\Campaign\Model\Coupon;
-use OpenLoyalty\Domain\Campaign\ReadModel\CouponUsageRepository;
 use OpenLoyalty\Domain\Campaign\SegmentId;
-use OpenLoyalty\Domain\Customer\Customer;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetails;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomersBelongingToOneLevel;
 use OpenLoyalty\Domain\Level\Level;
 use OpenLoyalty\Domain\Level\LevelId;
-use OpenLoyalty\Domain\Segment\ReadModel\SegmentedCustomersRepository;
 use OpenLoyalty\Domain\Segment\Segment;
 
 /**
@@ -25,7 +17,6 @@ use OpenLoyalty\Domain\Segment\Segment;
  */
 class CustomerDetailsCsvFormatterTest extends \PHPUnit_Framework_TestCase
 {
-
     protected $repo;
     protected $custDetailsRepo;
     protected $levelRepo;
@@ -34,9 +25,9 @@ class CustomerDetailsCsvFormatterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->repo = $this->getMock(RepositoryInterface::class);
-        $this->custDetailsRepo = $this->getMock(RepositoryInterface::class);
-        $this->levelRepo = $this->getMock(RepositoryInterface::class);
+        $this->repo = $this->getMockBuilder(RepositoryInterface::class)->getMock();
+        $this->custDetailsRepo = $this->getMockBuilder(RepositoryInterface::class)->getMock();
+        $this->levelRepo = $this->getMockBuilder(RepositoryInterface::class)->getMock();
 
         $customerDetails = $this->getMockBuilder(CustomerDetails::class)->setMockClassName('CustomerDetails')->disableOriginalConstructor()->getMock();
         $customerDetails->method('getBirthDate')->willReturn(new \DateTime());
@@ -62,16 +53,17 @@ class CustomerDetailsCsvFormatterTest extends \PHPUnit_Framework_TestCase
         $this->segment = $this->getMockBuilder(Segment::class)->disableOriginalConstructor()->getMock();
         $this->segment->method('getSegmentId')->willReturn($segmentId);
 
-        $this->repo ->method('findBy')->with($this->arrayHasKey('segmentId'))
+        $this->repo->method('findBy')->with($this->arrayHasKey('segmentId'))
             ->willReturn([$account]);
-        $this->levelRepo ->method('findBy')->with($this->arrayHasKey('levelId'))
+        $this->levelRepo->method('findBy')->with($this->arrayHasKey('levelId'))
             ->willReturn([$customersLevel]);
         $this->custDetailsRepo->method('find')->willReturn($customerDetails);
     }
+
     /**
      * @test
      */
-    public function it_returns_properly_formated_csv()
+    public function it_returns_properly_formatted_csv()
     {
         $formatter = new CustomerDetailsCsvFormatter($this->repo, $this->custDetailsRepo, $this->levelRepo);
         $segment = $formatter->getFormattedSegmentUsers($this->segment);

--- a/backend/tests/OpenLoyalty/Domain/Account/ReadModel/PointsTransferDetailsProjectorTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Account/ReadModel/PointsTransferDetailsProjectorTest.php
@@ -36,27 +36,27 @@ class PointsTransferDetailsProjectorTest extends ProjectorScenarioTestCase
     protected $customerId;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function createProjector(InMemoryRepository $repository)
     {
         $this->accountId = new AccountId('00000000-0000-0000-0000-000000000000');
         $this->customerId = new CustomerId('00000000-1111-0000-0000-000000000000');
 
-        $accountRepository = $this->getMock(InMemoryRepository::class);
+        $accountRepository = $this->getMockBuilder(InMemoryRepository::class)->getMock();
         $account = Account::createAccount($this->accountId, $this->customerId);
 
         $accountRepository->method('find')->willReturn($account);
-        $customerRepository = $this->getMock(InMemoryRepository::class);
+        $customerRepository = $this->getMockBuilder(InMemoryRepository::class)->getMock();
         $customer = Customer::registerCustomer(
             new \OpenLoyalty\Domain\Customer\CustomerId($this->customerId->__toString()),
             $this->getCustomerData()
         );
         $customerRepository->method('find')->willReturn($customer);
 
-        $transactionRepo = $this->getMock(TransactionDetailsRepository::class);
+        $transactionRepo = $this->getMockBuilder(TransactionDetailsRepository::class)->getMock();
         $transactionRepo->method('find')->willReturn(null);
-        $posRepo = $this->getMock(PosRepository::class);
+        $posRepo = $this->getMockBuilder(PosRepository::class)->getMock();
 
         return new PointsTransferDetailsProjector($repository, $accountRepository, $customerRepository, $transactionRepo, $posRepo);
     }
@@ -76,7 +76,7 @@ class PointsTransferDetailsProjectorTest extends ProjectorScenarioTestCase
         $this->scenario->given(array())
             ->when(new PointsWereAdded($this->accountId, new AddPointsTransfer($pointsId, 100, $date)))
             ->then(array(
-                $expectedReadModel
+                $expectedReadModel,
             ));
     }
 
@@ -95,7 +95,7 @@ class PointsTransferDetailsProjectorTest extends ProjectorScenarioTestCase
         $this->scenario->given(array())
             ->when(new PointsWereSpent($this->accountId, new SpendPointsTransfer($pointsId, 100, $date)))
             ->then(array(
-                $expectedReadModel
+                $expectedReadModel,
             ));
     }
 
@@ -113,11 +113,11 @@ class PointsTransferDetailsProjectorTest extends ProjectorScenarioTestCase
         $expectedReadModel->setCreatedAt($date);
         $this->scenario
             ->given(array(
-                new PointsWereAdded($this->accountId, new AddPointsTransfer($pointsId, 100, $date))
+                new PointsWereAdded($this->accountId, new AddPointsTransfer($pointsId, 100, $date)),
             ))
             ->when(new PointsTransferHasBeenCanceled($this->accountId, $pointsId))
             ->then(array(
-                $expectedReadModel
+                $expectedReadModel,
             ));
     }
 
@@ -135,11 +135,11 @@ class PointsTransferDetailsProjectorTest extends ProjectorScenarioTestCase
         $expectedReadModel->setCreatedAt($date);
         $this->scenario
             ->given(array(
-                new PointsWereAdded($this->accountId, new AddPointsTransfer($pointsId, 100, $date))
+                new PointsWereAdded($this->accountId, new AddPointsTransfer($pointsId, 100, $date)),
             ))
             ->when(new PointsTransferHasBeenExpired($this->accountId, $pointsId))
             ->then(array(
-                $expectedReadModel
+                $expectedReadModel,
             ));
     }
 
@@ -152,7 +152,7 @@ class PointsTransferDetailsProjectorTest extends ProjectorScenarioTestCase
         $pointsId = new PointsTransferId('00000000-0000-0000-0000-000000000000');
         $this->scenario
             ->given(array(
-                new PointsWereSpent($this->accountId, new SpendPointsTransfer($pointsId, 100))
+                new PointsWereSpent($this->accountId, new SpendPointsTransfer($pointsId, 100)),
             ))
             ->when(new PointsTransferHasBeenExpired($this->accountId, $pointsId))
             ->then(array(
@@ -192,8 +192,8 @@ class PointsTransferDetailsProjectorTest extends ProjectorScenarioTestCase
                 'city' => 'Wrocław',
                 'country' => 'PL',
                 'postal' => '50-300',
-                'province' => 'Dolnośląskie'
-            ]
+                'province' => 'Dolnośląskie',
+            ],
         ];
     }
 }

--- a/backend/tests/OpenLoyalty/Domain/Campaign/Command/CampaignCommandHandlerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Campaign/Command/CampaignCommandHandlerTest.php
@@ -21,7 +21,7 @@ abstract class CampaignCommandHandlerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $campaigns = &$this->campaigns;
-        $this->inMemoryRepository = $this->getMock(CampaignRepository::class);
+        $this->inMemoryRepository = $this->getMockBuilder(CampaignRepository::class)->getMock();
         $this->inMemoryRepository->method('save')->with($this->isInstanceOf(Campaign::class))->will(
             $this->returnCallback(function($campaign) use (&$campaigns) {
                 $campaigns[] = $campaign;

--- a/backend/tests/OpenLoyalty/Domain/Customer/Command/AssignPosToCustomerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/Command/AssignPosToCustomerTest.php
@@ -25,8 +25,8 @@ class AssignPosToCustomerTest extends CustomerCommandHandlerTest
      */
     public function it_updates_customer_name()
     {
-        $customerId    = new CustomerId('00000000-0000-0000-0000-000000000000');
-        $posId    = new PosId('00000000-0000-0000-0000-000000000011');
+        $customerId = new CustomerId('00000000-0000-0000-0000-000000000000');
+        $posId = new PosId('00000000-0000-0000-0000-000000000011');
         $this->scenario
             ->withAggregateId($customerId)
             ->given([
@@ -34,7 +34,7 @@ class AssignPosToCustomerTest extends CustomerCommandHandlerTest
             ])
             ->when(new AssignPosToCustomer($customerId, $posId))
             ->then([
-                new PosWasAssignedToCustomer($customerId, $posId)
+                new PosWasAssignedToCustomer($customerId, $posId),
             ]);
     }
 
@@ -44,7 +44,7 @@ class AssignPosToCustomerTest extends CustomerCommandHandlerTest
     public function it_dispatch_event_on_update()
     {
         $customerId = new CustomerId('00000000-0000-0000-0000-000000000000');
-        $posId  = new PosId('00000000-0000-0000-0000-000000000011');
+        $posId = new PosId('00000000-0000-0000-0000-000000000011');
 
         $eventStore = new TraceableEventStore(new InMemoryEventStore());
 
@@ -53,7 +53,7 @@ class AssignPosToCustomerTest extends CustomerCommandHandlerTest
         $eventStore->append($customerId, new DomainEventStream($messages));
 
         $eventBus = new SimpleEventBus();
-        $eventDispatcher = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
         $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')

--- a/backend/tests/OpenLoyalty/Domain/Customer/Command/CustomerCommandHandlerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/Command/CustomerCommandHandlerTest.php
@@ -6,14 +6,11 @@ use Broadway\CommandHandling\Testing\CommandHandlerScenarioTestCase;
 use Broadway\EventDispatcher\EventDispatcherInterface;
 use Broadway\EventHandling\EventBusInterface;
 use Broadway\EventStore\EventStoreInterface;
-use OpenLoyalty\Domain\Customer\Command\CustomerCommandHandler;
 use OpenLoyalty\Domain\Customer\CustomerRepository;
 use OpenLoyalty\Domain\Customer\Validator\CustomerUniqueValidator;
 
 /**
  * Class CustomerCommandHandlerTest.
- *
- * @package OpenLoyalty\Domain\Customer\Command
  */
 abstract class CustomerCommandHandlerTest extends CommandHandlerScenarioTestCase
 {
@@ -22,7 +19,7 @@ abstract class CustomerCommandHandlerTest extends CommandHandlerScenarioTestCase
      */
     protected function createCommandHandler(EventStoreInterface $eventStore, EventBusInterface $eventBus)
     {
-        $eventDispatcher = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
         $eventDispatcher->method('dispatch')->with($this->isType('string'))->willReturn(true);
 
         return $this->getCustomerCommandHandler($eventStore, $eventBus, $eventDispatcher);
@@ -51,20 +48,21 @@ abstract class CustomerCommandHandlerTest extends CommandHandlerScenarioTestCase
                 'city' => 'Wrocław',
                 'country' => 'PL',
                 'postal' => '50-300',
-                'province' => 'Dolnośląskie'
-            ]
+                'province' => 'Dolnośląskie',
+            ],
         ];
     }
 
     /**
-     * @param EventStoreInterface $eventStore
-     * @param EventBusInterface $eventBus
+     * @param EventStoreInterface      $eventStore
+     * @param EventBusInterface        $eventBus
+     * @param EventDispatcherInterface $eventDispatcher
      *
      * @return \OpenLoyalty\Domain\Customer\Command\CustomerCommandHandler
      */
     protected function getCustomerCommandHandler(EventStoreInterface $eventStore, EventBusInterface $eventBus, EventDispatcherInterface $eventDispatcher)
     {
-        $customerDetailsRepository = $this->getMock('Broadway\ReadModel\RepositoryInterface');
+        $customerDetailsRepository = $this->getMockBuilder('Broadway\ReadModel\RepositoryInterface')->getMock();
         $customerDetailsRepository->method('findBy')->willReturn([]);
         $validator = new CustomerUniqueValidator($customerDetailsRepository);
 

--- a/backend/tests/OpenLoyalty/Domain/Customer/Command/DeactivateCustomerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/Command/DeactivateCustomerTest.php
@@ -2,19 +2,9 @@
 
 namespace OpenLoyalty\Domain\Customer\Command;
 
-use Broadway\Domain\DomainEventStream;
-use Broadway\Domain\DomainMessage;
-use Broadway\Domain\Metadata;
-use Broadway\EventDispatcher\EventDispatcherInterface;
-use Broadway\EventHandling\SimpleEventBus;
-use Broadway\EventStore\InMemoryEventStore;
-use Broadway\EventStore\TraceableEventStore;
 use OpenLoyalty\Domain\Customer\CustomerId;
 use OpenLoyalty\Domain\Customer\Event\CustomerWasDeactivated;
 use OpenLoyalty\Domain\Customer\Event\CustomerWasRegistered;
-use OpenLoyalty\Domain\Customer\Event\PosWasAssignedToCustomer;
-use OpenLoyalty\Domain\Customer\PosId;
-use OpenLoyalty\Domain\Customer\SystemEvent\CustomerSystemEvents;
 
 /**
  * Class DeactivateCustomerTest.
@@ -26,7 +16,7 @@ class DeactivateCustomerTest extends CustomerCommandHandlerTest
      */
     public function it_deactivates_customer()
     {
-        $customerId    = new CustomerId('00000000-0000-0000-0000-000000000000');
+        $customerId = new CustomerId('00000000-0000-0000-0000-000000000000');
         $this->scenario
             ->withAggregateId($customerId)
             ->given([
@@ -34,7 +24,7 @@ class DeactivateCustomerTest extends CustomerCommandHandlerTest
             ])
             ->when(new DeactivateCustomer($customerId))
             ->then([
-                new CustomerWasDeactivated($customerId)
+                new CustomerWasDeactivated($customerId),
             ]);
     }
 }

--- a/backend/tests/OpenLoyalty/Domain/Customer/Command/RegisterCustomerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/Command/RegisterCustomerTest.php
@@ -12,8 +12,6 @@ use OpenLoyalty\Domain\Customer\SystemEvent\CustomerSystemEvents;
 
 /**
  * Class RegisterCustomerTest.
- *
- * @package OpenLoyalty\Domain\User\Command
  */
 class RegisterCustomerTest extends CustomerCommandHandlerTest
 {
@@ -28,7 +26,7 @@ class RegisterCustomerTest extends CustomerCommandHandlerTest
             ->given([])
             ->when(new RegisterCustomer($customerId, CustomerCommandHandlerTest::getCustomerData()))
             ->then(array(
-                new CustomerWasRegistered($customerId, CustomerCommandHandlerTest::getCustomerData())
+                new CustomerWasRegistered($customerId, CustomerCommandHandlerTest::getCustomerData()),
             ));
     }
 
@@ -42,7 +40,7 @@ class RegisterCustomerTest extends CustomerCommandHandlerTest
         $eventStore = new TraceableEventStore(new InMemoryEventStore());
 
         $eventBus = new SimpleEventBus();
-        $eventDispatcher = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
         $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')

--- a/backend/tests/OpenLoyalty/Domain/Customer/Command/UpdateCustomerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/Command/UpdateCustomerTest.php
@@ -17,8 +17,6 @@ use OpenLoyalty\Domain\Customer\SystemEvent\CustomerSystemEvents;
 
 /**
  * Class UpdateCustomerTest.
- *
- * @package OpenLoyalty\Domain\User\Command
  */
 class UpdateCustomerTest extends CustomerCommandHandlerTest
 {
@@ -35,7 +33,7 @@ class UpdateCustomerTest extends CustomerCommandHandlerTest
             ])
             ->when(new UpdateCustomerDetails($customerId, ['firstName' => 'Jane']))
             ->then([
-                new CustomerDetailsWereUpdated($customerId, ['firstName' => 'Jane'])
+                new CustomerDetailsWereUpdated($customerId, ['firstName' => 'Jane']),
             ]);
     }
 
@@ -53,7 +51,7 @@ class UpdateCustomerTest extends CustomerCommandHandlerTest
         $eventStore->append($customerId, new DomainEventStream($messages));
 
         $eventBus = new SimpleEventBus();
-        $eventDispatcher = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
         $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
@@ -77,7 +75,7 @@ class UpdateCustomerTest extends CustomerCommandHandlerTest
         $eventStore->append($customerId, new DomainEventStream($messages));
 
         $eventBus = new SimpleEventBus();
-        $eventDispatcher = $this->getMock(EventDispatcherInterface::class);
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
         $eventDispatcher
             ->expects($this->at(0))
             ->method('dispatch')

--- a/backend/tests/OpenLoyalty/Domain/Customer/ReadModel/CustomerDetailsProjectorTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/ReadModel/CustomerDetailsProjectorTest.php
@@ -20,11 +20,11 @@ use OpenLoyalty\Domain\Transaction\ReadModel\TransactionDetailsRepository;
 class CustomerDetailsProjectorTest extends ProjectorScenarioTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function createProjector(InMemoryRepository $repository)
     {
-        $transactionDetailsRepo = $this->getMock(TransactionDetailsRepository::class);
+        $transactionDetailsRepo = $this->getMockBuilder(TransactionDetailsRepository::class)->getMock();
 
         return new CustomerDetailsProjector($repository, $transactionDetailsRepo);
     }
@@ -134,12 +134,14 @@ class CustomerDetailsProjectorTest extends ProjectorScenarioTestCase
         unset($data['loyaltyCardNumber']);
         unset($data['company']);
         unset($data['address']);
+
         return CustomerDetails::deserialize($data);
     }
 
     private function createReadModel(CustomerId $customerId, array $data)
     {
         $data['id'] = $customerId->__toString();
+
         return CustomerDetails::deserialize($data);
     }
 }

--- a/backend/tests/OpenLoyalty/Domain/Customer/ReadModel/CustomersBelongingToOneLevelProjectorTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/ReadModel/CustomersBelongingToOneLevelProjectorTest.php
@@ -41,7 +41,7 @@ class CustomersBelongingToOneLevelProjectorTest extends ProjectorScenarioTestCas
         $this->levelId = new LevelId('00000000-2222-0000-0000-000000000111');
         $this->level2Id = new LevelId('00000000-2222-0000-0000-000000000222');
 
-        $customerRepository = $this->getMock(InMemoryRepository::class);
+        $customerRepository = $this->getMockBuilder(InMemoryRepository::class)->getMock();
         $customerData = $this->getCustomerData($this->levelId);
         $customerData['id'] = $this->customerId->__toString();
         $customer = CustomerDetails::deserialize($customerData);
@@ -61,7 +61,7 @@ class CustomersBelongingToOneLevelProjectorTest extends ProjectorScenarioTestCas
                     return $customer2;
                 }
             }));
-        $levelRepo = $this->getMock(LevelRepository::class);
+        $levelRepo = $this->getMockBuilder(LevelRepository::class)->getMock();
         $levelRepo->method('byId')->willReturn(null);
 
         return new CustomersBelongingToOneLevelProjector($customerRepository, $repository, $levelRepo);
@@ -88,7 +88,7 @@ class CustomersBelongingToOneLevelProjectorTest extends ProjectorScenarioTestCas
     {
         $this->scenario
             ->given([
-                new CustomerWasMovedToLevel($this->customerId, $this->levelId)
+                new CustomerWasMovedToLevel($this->customerId, $this->levelId),
             ])
             ->when(new CustomerWasMovedToLevel($this->customerId, $this->level2Id))
             ->then(array(
@@ -104,18 +104,18 @@ class CustomersBelongingToOneLevelProjectorTest extends ProjectorScenarioTestCas
     {
         $this->scenario
             ->given([
-                new CustomerWasMovedToLevel($this->customerId, $this->levelId)
+                new CustomerWasMovedToLevel($this->customerId, $this->levelId),
             ])
             ->when(new CustomerWasMovedToLevel($this->customer2Id, $this->levelId))
             ->then(array(
                 $this->createBaseReadModelWithMultipleCustomers($this->levelId, [
                     [
                         'id' => $this->customerId,
-                        'data' => $this->getCustomerData($this->levelId)
+                        'data' => $this->getCustomerData($this->levelId),
                     ],
                     [
                         'id' => $this->customer2Id,
-                        'data' => $this->getCustomerData($this->levelId, 'Andrzej')
+                        'data' => $this->getCustomerData($this->levelId, 'Andrzej'),
                     ],
                 ]),
             ));
@@ -166,8 +166,8 @@ class CustomersBelongingToOneLevelProjectorTest extends ProjectorScenarioTestCas
                 'city' => 'Wrocław',
                 'country' => 'PL',
                 'postal' => '50-300',
-                'province' => 'Dolnośląskie'
-            ]
+                'province' => 'Dolnośląskie',
+            ],
         ];
     }
 }

--- a/backend/tests/OpenLoyalty/Domain/Customer/Validator/CustomerUniqueValidatorTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Customer/Validator/CustomerUniqueValidatorTest.php
@@ -33,7 +33,7 @@ class CustomerUniqueValidatorTest extends \PHPUnit_Framework_TestCase
             'c@c.com' => $customer3,
         ];
 
-        $this->customerDetailsRepository = $this->getMock('Broadway\ReadModel\RepositoryInterface');
+        $this->customerDetailsRepository = $this->getMockBuilder('Broadway\ReadModel\RepositoryInterface')->getMock();
         $this->customerDetailsRepository->method('findBy')->with($this->logicalOr(
                 $this->arrayHasKey('email'),
                 $this->arrayHasKey('loyaltyCardNumber')
@@ -41,6 +41,7 @@ class CustomerUniqueValidatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnCallback(function($params) use ($customers) {
                 if (isset($params['email'])) {
                     $email = $params['email'];
+
                     return array_filter($customers, function(CustomerDetails $customerDetails) use ($email) {
                         if ($customerDetails->getEmail() == $email) {
                             return true;
@@ -51,6 +52,7 @@ class CustomerUniqueValidatorTest extends \PHPUnit_Framework_TestCase
                 }
                 if (isset($params['loyaltyCardNumber'])) {
                     $loyaltyCardNumber = $params['loyaltyCardNumber'];
+
                     return array_filter($customers, function(CustomerDetails $customerDetails) use ($loyaltyCardNumber) {
                         if ($customerDetails->getLoyaltyCardNumber() == $loyaltyCardNumber) {
                             return true;

--- a/backend/tests/OpenLoyalty/Domain/EarningRule/Command/CreateEarningRuleTest.php
+++ b/backend/tests/OpenLoyalty/Domain/EarningRule/Command/CreateEarningRuleTest.php
@@ -7,7 +7,6 @@ use OpenLoyalty\Domain\EarningRule\EarningRuleId;
 use OpenLoyalty\Domain\EarningRule\EventEarningRule;
 use OpenLoyalty\Domain\EarningRule\PointsEarningRule;
 use OpenLoyalty\Domain\EarningRule\ProductPurchaseEarningRule;
-use OpenLoyalty\Domain\Model\SKU;
 
 /**
  * Class CreateEarningRuleTest.
@@ -90,7 +89,7 @@ class CreateEarningRuleTest extends EarningRuleCommandHandlerTest
             'startAt' => (new \DateTime())->getTimestamp(),
             'endAt' => (new \DateTime('+1 month'))->getTimestamp(),
             'skuIds' => ['123'],
-            'pointsAmount' => 100
+            'pointsAmount' => 100,
         ]);
         $handler->handle($command);
         $rule = $this->inMemoryRepository->byId($ruleId);

--- a/backend/tests/OpenLoyalty/Domain/EarningRule/Command/EarningRuleCommandHandlerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/EarningRule/Command/EarningRuleCommandHandlerTest.php
@@ -3,9 +3,9 @@
 namespace OpenLoyalty\Domain\EarningRule\Command;
 
 use Broadway\UuidGenerator\Rfc4122\Version4Generator;
-use Broadway\UuidGenerator\UuidGeneratorInterface;
 use OpenLoyalty\Domain\EarningRule\EarningRule;
 use OpenLoyalty\Domain\EarningRule\EarningRuleId;
+use OpenLoyalty\Domain\EarningRule\EarningRuleRepository;
 
 /**
  * Class EarningRuleCommandHandlerTest.
@@ -19,7 +19,7 @@ abstract class EarningRuleCommandHandlerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $rules = &$this->rules;
-        $this->inMemoryRepository = $this->getMock('OpenLoyalty\Domain\EarningRule\EarningRuleRepository');
+        $this->inMemoryRepository = $this->getMockBuilder(EarningRuleRepository::class)->getMock();
         $this->inMemoryRepository->method('save')->with($this->isInstanceOf(EarningRule::class))->will(
             $this->returnCallback(function($rule) use (&$rules) {
                 $rules[] = $rule;

--- a/backend/tests/OpenLoyalty/Domain/Pos/Command/PosCommandHandlerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Pos/Command/PosCommandHandlerTest.php
@@ -4,6 +4,7 @@ namespace OpenLoyalty\Domain\Pos\Command;
 
 use OpenLoyalty\Domain\Pos\Pos;
 use OpenLoyalty\Domain\Pos\PosId;
+use OpenLoyalty\Domain\Pos\PosRepository;
 
 /**
  * Class PosCommandHandlerTest.
@@ -17,7 +18,7 @@ abstract class PosCommandHandlerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $poss = &$this->poss;
-        $this->inMemoryRepository = $this->getMock('OpenLoyalty\Domain\Pos\PosRepository');
+        $this->inMemoryRepository = $this->getMockBuilder(PosRepository::class)->getMock();
         $this->inMemoryRepository->method('save')->with($this->isInstanceOf(Pos::class))->will(
             $this->returnCallback(function($pos) use (&$poss) {
                 $poss[] = $pos;

--- a/backend/tests/OpenLoyalty/Domain/Segment/Command/CreateSegmentTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Segment/Command/CreateSegmentTest.php
@@ -2,9 +2,6 @@
 
 namespace OpenLoyalty\Domain\Segment\Command;
 
-use OpenLoyalty\Domain\Segment\Model\Criteria\AverageTransactionAmount;
-use OpenLoyalty\Domain\Segment\Model\Criteria\BoughtInPos;
-use OpenLoyalty\Domain\Segment\Model\Criteria\TransactionCount;
 use OpenLoyalty\Domain\Segment\Model\Criterion;
 use OpenLoyalty\Domain\Segment\Segment;
 use OpenLoyalty\Domain\Segment\SegmentId;
@@ -47,7 +44,7 @@ class CreateSegmentTest extends SegmentCommandHandlerTest
                             'min' => 10,
                             'max' => 20,
                         ],
-                    ]
+                    ],
                 ],
             ],
         ]);

--- a/backend/tests/OpenLoyalty/Domain/Segment/Command/SegmentCommandHandlerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Segment/Command/SegmentCommandHandlerTest.php
@@ -4,6 +4,8 @@ namespace OpenLoyalty\Domain\Segment\Command;
 
 use OpenLoyalty\Domain\Segment\Segment;
 use OpenLoyalty\Domain\Segment\SegmentId;
+use OpenLoyalty\Domain\Segment\SegmentRepository;
+use OpenLoyalty\Domain\Segment\SegmentPartRepository;
 
 /**
  * Class SegmentCommandHandlerTest.
@@ -24,9 +26,9 @@ abstract class SegmentCommandHandlerTest extends \PHPUnit_Framework_TestCase
         $this->segment[] = $segment;
 
         $segments = &$this->segment;
-        $this->inMemoryRepository = $this->getMock('OpenLoyalty\Domain\Segment\SegmentRepository');
-        $this->partsInMemoryRepository = $this->getMock('OpenLoyalty\Domain\Segment\SegmentPartRepository');
-        $this->eventDispatcher = $this->getMock('Broadway\EventDispatcher\EventDispatcher');
+        $this->inMemoryRepository = $this->getMockBuilder(SegmentRepository::class)->getMock();
+        $this->partsInMemoryRepository = $this->getMockBuilder(SegmentPartRepository::class)->getMock();
+        $this->eventDispatcher = $this->getMockBuilder('Broadway\EventDispatcher\EventDispatcher')->getMock();
         $this->partsInMemoryRepository->method('remove')->with($this->any())->willReturn(true);
         $this->inMemoryRepository->method('save')->with($this->isInstanceOf(Segment::class))->will(
             $this->returnCallback(function($segment) use (&$segments) {

--- a/backend/tests/OpenLoyalty/Domain/Segment/Segmentation/SegmentationProviderTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Segment/Segmentation/SegmentationProviderTest.php
@@ -5,8 +5,6 @@ namespace OpenLoyalty\Domain\Segment\Segmentation;
 use Broadway\ReadModel\RepositoryInterface;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetails;
 use OpenLoyalty\Domain\Customer\ReadModel\CustomerDetailsRepository;
-use OpenLoyalty\Domain\Customer\ReadModel\CustomerTransactionsSummary;
-use OpenLoyalty\Domain\Customer\ReadModel\CustomerTransactionsSummaryRepository;
 use OpenLoyalty\Domain\Model\SKU;
 use OpenLoyalty\Domain\Segment\CriterionId;
 use OpenLoyalty\Domain\Segment\Model\Criteria\AverageTransactionAmount;
@@ -40,7 +38,7 @@ class SegmentationProviderTest extends \PHPUnit_Framework_TestCase
     protected $transactionDetailsRepository;
 
     /**
-     * @var CustomerTransactionsSummaryRepository
+     * @var CustomerDetailsRepository
      */
     protected $customerDetailsRepository;
 
@@ -101,7 +99,7 @@ class SegmentationProviderTest extends \PHPUnit_Framework_TestCase
         $posTransaction4->setItems([new Item(new SKU('123'), 'item1', 1, 99, 'test', 'test')]);
         $transactions[] = $posTransaction4;
 
-        $this->transactionDetailsRepository = $this->getMock(TransactionDetailsRepository::class);
+        $this->transactionDetailsRepository = $this->getMockBuilder(TransactionDetailsRepository::class)->getMock();
         $this->transactionDetailsRepository->method('findBy')->with($this->arrayHasKey('posId'))->will(
             $this->returnCallback(function (array $arg) use ($transactions) {
                 $posId = $arg['posId'];
@@ -119,7 +117,7 @@ class SegmentationProviderTest extends \PHPUnit_Framework_TestCase
         $this->transactionDetailsRepository->method('findAll')->willReturn($transactions);
         $this->transactionDetailsRepository->method('findAllWithCustomer')->willReturn($transactions);
 
-        $this->customerDetailsRepository = $this->getMock(CustomerDetailsRepository::class);
+        $this->customerDetailsRepository = $this->getMockBuilder(CustomerDetailsRepository::class)->getMock();
         $this->customerDetailsRepository->method('findAllWithAverageTransactionAmountBetween')
             ->with(
                 $this->logicalOr($this->equalTo(40), $this->equalTo(0)),
@@ -168,7 +166,7 @@ class SegmentationProviderTest extends \PHPUnit_Framework_TestCase
                 return [];
             }));
 
-        $this->customerValidator = $this->getMock(CustomerValidator::class);
+        $this->customerValidator = $this->getMockBuilder(CustomerValidator::class)->getMock();
         $this->customerValidator->method('isValid')->with($this->isInstanceOf(CustomerId::class))->willReturn(true);
 
         $this->segmentationProvider = new SegmentationProvider();

--- a/backend/tests/OpenLoyalty/Domain/Seller/Command/SellerCommandHandlerTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Seller/Command/SellerCommandHandlerTest.php
@@ -15,7 +15,7 @@ abstract class SellerCommandHandlerTest extends CommandHandlerScenarioTestCase
 {
     protected function createCommandHandler(EventStoreInterface $eventStore, EventBusInterface $eventBus)
     {
-        $sellerDetailsRepository = $this->getMock('Broadway\ReadModel\RepositoryInterface');
+        $sellerDetailsRepository = $this->getMockBuilder('Broadway\ReadModel\RepositoryInterface')->getMock();
         $sellerDetailsRepository->method('findBy')->willReturn([]);
         $validator = new SellerUniqueValidator($sellerDetailsRepository);
 

--- a/backend/tests/OpenLoyalty/Domain/Seller/ReadModel/SellerDetailsProjectorTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Seller/ReadModel/SellerDetailsProjectorTest.php
@@ -20,12 +20,15 @@ use OpenLoyalty\Domain\Seller\SellerId;
 class SellerDetailsProjectorTest extends ProjectorScenarioTestCase
 {
     /**
+     * @param InMemoryRepository $repository
+     *
      * @return Projector
      */
     protected function createProjector(InMemoryRepository $repository)
     {
-        $posRepo = $this->getMock(PosRepository::class);
+        $posRepo = $this->getMockBuilder(PosRepository::class)->getMock();
         $posRepo->method('findBy')->willReturn(null);
+
         return new SellerDetailsProjector($repository, $posRepo);
     }
 
@@ -104,7 +107,7 @@ class SellerDetailsProjectorTest extends ProjectorScenarioTestCase
         $this->scenario
             ->given(array(
                 new SellerWasRegistered($sellerId, $data),
-                new SellerWasActivated($sellerId)
+                new SellerWasActivated($sellerId),
             ))
             ->when(new SellerWasDeactivated($sellerId))
             ->then(array(

--- a/backend/tests/OpenLoyalty/Domain/Seller/Validator/SellerUniqueValidatorTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Seller/Validator/SellerUniqueValidatorTest.php
@@ -30,13 +30,14 @@ class SellerUniqueValidatorTest extends \PHPUnit_Framework_TestCase
             'c@c.com' => $seller3,
         ];
 
-        $this->sellerDetailsRepository = $this->getMock('Broadway\ReadModel\RepositoryInterface');
+        $this->sellerDetailsRepository = $this->getMockBuilder('Broadway\ReadModel\RepositoryInterface')->getMock();
         $this->sellerDetailsRepository->method('findBy')->with(
             $this->arrayHasKey('email')
         )
             ->will($this->returnCallback(function($params) use ($sellers) {
                 if (isset($params['email'])) {
                     $email = $params['email'];
+
                     return array_filter($sellers, function(SellerDetails $sellerDetails) use ($email) {
                         if ($sellerDetails->getEmail() == $email) {
                             return true;

--- a/backend/tests/OpenLoyalty/Domain/Transaction/Command/RegisterTransactionTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Transaction/Command/RegisterTransactionTest.php
@@ -2,8 +2,6 @@
 
 namespace OpenLoyalty\Domain\Transaction\Command;
 
-use OpenLoyalty\Domain\Customer\Command\CustomerCommandHandlerTest;
-use OpenLoyalty\Domain\Customer\CustomerId;
 use OpenLoyalty\Domain\Transaction\Event\TransactionWasRegistered;
 use OpenLoyalty\Domain\Transaction\PosId;
 use OpenLoyalty\Domain\Transaction\TransactionId;
@@ -76,7 +74,7 @@ class RegisterTransactionTest extends TransactionCommandHandlerTest
                     $transactionData,
                     $customerData,
                     $items
-                )
+                ),
             ));
     }
 
@@ -146,7 +144,7 @@ class RegisterTransactionTest extends TransactionCommandHandlerTest
                     $customerData,
                     $items,
                     $posId
-                )
+                ),
             ));
     }
 }

--- a/backend/tests/OpenLoyalty/Domain/Transaction/ReadModel/TransactionDetailsProjectorTest.php
+++ b/backend/tests/OpenLoyalty/Domain/Transaction/ReadModel/TransactionDetailsProjectorTest.php
@@ -24,7 +24,7 @@ class TransactionDetailsProjectorTest extends ProjectorScenarioTestCase
      */
     protected function createProjector(InMemoryRepository $repository)
     {
-        $posRepo = $this->getMock(PosRepository::class);
+        $posRepo = $this->getMockBuilder(PosRepository::class)->getMock();
         $posRepo->method('byId')->willReturn(null);
 
         return new TransactionDetailsProjector($repository, $posRepo);
@@ -78,7 +78,7 @@ class TransactionDetailsProjectorTest extends ProjectorScenarioTestCase
         $this->scenario->given([])
             ->when(new TransactionWasRegistered($transactionId, $transactionData, $customerData, $items, $posId))
             ->then([
-                $expectedReadModel
+                $expectedReadModel,
             ]);
     }
 
@@ -101,11 +101,11 @@ class TransactionDetailsProjectorTest extends ProjectorScenarioTestCase
 
         $this->scenario
             ->given([
-                new TransactionWasRegistered($transactionId, $this->getTransactionData(), $this->getCustomerData())
+                new TransactionWasRegistered($transactionId, $this->getTransactionData(), $this->getCustomerData()),
             ])
             ->when(new CustomerWasAssignedToTransaction($transactionId, $customerId))
             ->then(array(
-                $expectedReadModel
+                $expectedReadModel,
             ));
     }
 

--- a/backend/tests/OpenLoyalty/Infrastructure/Account/Event/Listener/SpendPointsOnCampaignListenerTest.php
+++ b/backend/tests/OpenLoyalty/Infrastructure/Account/Event/Listener/SpendPointsOnCampaignListenerTest.php
@@ -13,9 +13,7 @@ use OpenLoyalty\Domain\Account\ReadModel\AccountDetails;
 use OpenLoyalty\Domain\Customer\CampaignId;
 use OpenLoyalty\Domain\Customer\CustomerId;
 use OpenLoyalty\Domain\Customer\Event\CampaignWasBoughtByCustomer;
-use OpenLoyalty\Domain\Customer\Model\CampaignPurchase;
 use OpenLoyalty\Domain\Customer\Model\Coupon;
-use OpenLoyalty\Domain\Customer\SystemEvent\CustomerBoughtCampaignSystemEvent;
 
 /**
  * Class SpendPointsOnCampaignListenerTest.
@@ -23,9 +21,10 @@ use OpenLoyalty\Domain\Customer\SystemEvent\CustomerBoughtCampaignSystemEvent;
 class SpendPointsOnCampaignListenerTest extends \PHPUnit_Framework_TestCase
 {
     protected $uuid = '00000000-0000-0000-0000-000000000000';
+
     protected function getUuidGenerator()
     {
-        $mock = $this->getMock(UuidGeneratorInterface::class);
+        $mock = $this->getMockBuilder(UuidGeneratorInterface::class)->getMock();
         $mock->method('generate')->willReturn($this->uuid);
 
         return $mock;
@@ -66,16 +65,15 @@ class SpendPointsOnCampaignListenerTest extends \PHPUnit_Framework_TestCase
         $account = $this->getMockBuilder(AccountDetails::class)->disableOriginalConstructor()->getMock();
         $account->method('getAccountId')->willReturn(new AccountId($this->uuid));
 
-        $repo = $this->getMock(RepositoryInterface::class);
+        $repo = $this->getMockBuilder(RepositoryInterface::class)->getMock();
         $repo->method('findBy')->with($this->arrayHasKey('customerId'))->willReturn([$account]);
 
         return $repo;
     }
 
-
     protected function getCommandBus($expected)
     {
-        $mock = $this->getMock(CommandBusInterface::class);
+        $mock = $this->getMockBuilder(CommandBusInterface::class)->getMock();
         $mock->method('dispatch')->with($this->equalTo($expected));
 
         return $mock;

--- a/backend/tests/OpenLoyalty/Infrastructure/Account/SytemEvent/Listener/ApplyEarningRuleToTransactionListenerTest.php
+++ b/backend/tests/OpenLoyalty/Infrastructure/Account/SytemEvent/Listener/ApplyEarningRuleToTransactionListenerTest.php
@@ -2,12 +2,10 @@
 
 namespace OpenLoyalty\Infrastructure\Account\SytemEvent\Listener;
 
-use Broadway\ReadModel\RepositoryInterface;
 use OpenLoyalty\Domain\Account\AccountId;
 use OpenLoyalty\Domain\Account\Command\AddPoints;
 use OpenLoyalty\Domain\Account\Model\AddPointsTransfer;
 use OpenLoyalty\Domain\Account\PointsTransferId;
-use OpenLoyalty\Domain\Account\ReadModel\AccountDetails;
 use OpenLoyalty\Domain\Transaction\CustomerId;
 use OpenLoyalty\Domain\Transaction\SystemEvent\CustomerAssignedToTransactionSystemEvent;
 use OpenLoyalty\Domain\Transaction\TransactionId;

--- a/backend/tests/OpenLoyalty/Infrastructure/Account/SytemEvent/Listener/BaseApplyEarningRuleListenerTest.php
+++ b/backend/tests/OpenLoyalty/Infrastructure/Account/SytemEvent/Listener/BaseApplyEarningRuleListenerTest.php
@@ -19,9 +19,10 @@ use OpenLoyalty\Infrastructure\Account\EarningRuleApplier;
 abstract class BaseApplyEarningRuleListenerTest extends \PHPUnit_Framework_TestCase
 {
     protected $uuid = '00000000-0000-0000-0000-000000000000';
+
     protected function getUuidGenerator()
     {
-        $mock = $this->getMock(UuidGeneratorInterface::class);
+        $mock = $this->getMockBuilder(UuidGeneratorInterface::class)->getMock();
         $mock->method('generate')->willReturn($this->uuid);
 
         return $mock;
@@ -32,7 +33,7 @@ abstract class BaseApplyEarningRuleListenerTest extends \PHPUnit_Framework_TestC
         $account = $this->getMockBuilder(AccountDetails::class)->disableOriginalConstructor()->getMock();
         $account->method('getAccountId')->willReturn(new AccountId($this->uuid));
 
-        $repo = $this->getMock(RepositoryInterface::class);
+        $repo = $this->getMockBuilder(RepositoryInterface::class)->getMock();
         $repo->method('findBy')->with($this->arrayHasKey('customerId'))->willReturn([$account]);
 
         return $repo;
@@ -40,7 +41,7 @@ abstract class BaseApplyEarningRuleListenerTest extends \PHPUnit_Framework_TestC
 
     protected function getCommandBus($expected)
     {
-        $mock = $this->getMock(CommandBusInterface::class);
+        $mock = $this->getMockBuilder(CommandBusInterface::class)->getMock();
         $mock->method('dispatch')->with($this->equalTo($expected));
 
         return $mock;
@@ -48,7 +49,7 @@ abstract class BaseApplyEarningRuleListenerTest extends \PHPUnit_Framework_TestC
 
     protected function getApplierForEvent($returnValue)
     {
-        $mock = $this->getMock(EarningRuleApplier::class);
+        $mock = $this->getMockBuilder(EarningRuleApplier::class)->getMock();
         $mock->method('evaluateEvent')->with($this->logicalOr(
             $this->equalTo(AccountSystemEvents::ACCOUNT_CREATED),
             $this->equalTo(TransactionSystemEvents::CUSTOMER_FIRST_TRANSACTION),
@@ -62,7 +63,7 @@ abstract class BaseApplyEarningRuleListenerTest extends \PHPUnit_Framework_TestC
 
     protected function getApplierForTransaction($returnValue)
     {
-        $mock = $this->getMock(EarningRuleApplier::class);
+        $mock = $this->getMockBuilder(EarningRuleApplier::class)->getMock();
         $mock->method('evaluateTransaction')->with($this->isInstanceOf(TransactionId::class))
             ->willReturn($returnValue);
 

--- a/backend/tests/OpenLoyalty/Infrastructure/Customer/SystemEvent/Listener/CalculateCustomerLevelListenerTest.php
+++ b/backend/tests/OpenLoyalty/Infrastructure/Customer/SystemEvent/Listener/CalculateCustomerLevelListenerTest.php
@@ -30,6 +30,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
     CONST LEVEL_WITH_REWARD_10_FROM_0 = '00000000-0000-0000-0000-000000000000';
     CONST LEVEL_WITH_REWARD_200_FROM_20 = '00000000-0000-0000-0000-000000000001';
     CONST LEVEL_WITH_REWARD_300_FROM_30 = '00000000-0000-0000-0000-000000000002';
+
     /**
      * @test
      */
@@ -39,7 +40,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
         $levelId = new LevelId('00000000-0000-0000-0000-000000000003');
         $level = new Level($levelId, 'test', 10);
 
-        $commandBus = $this->getMock(CommandBusInterface::class);
+        $commandBus = $this->getMockBuilder(CommandBusInterface::class)->getMock();
         $commandBus->expects($this->once())->method('dispatch')->with(
             $this->equalTo(
                 new MoveCustomerToLevel(
@@ -81,10 +82,9 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
         $levels = $this->getSampleLevels();
         $levelsRepo = $this->getLevelRepositoryWithArray($levels);
 
-
         $customerId = '00000000-0000-0000-0000-000000000000';
 
-        $commandBus = $this->getMock(CommandBusInterface::class);
+        $commandBus = $this->getMockBuilder(CommandBusInterface::class)->getMock();
         if ($resultLevelId == null) {
             $commandBus->expects($this->never())->method('dispatch');
         } else {
@@ -125,7 +125,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
         $levelId = new LevelId('00000000-0000-0000-0000-000000000003');
         $level = new Level($levelId, 'test', 0);
 
-        $commandBus = $this->getMock(CommandBusInterface::class);
+        $commandBus = $this->getMockBuilder(CommandBusInterface::class)->getMock();
         $commandBus->expects($this->once())->method('dispatch')->with(
             $this->equalTo(
                 new MoveCustomerToLevel(
@@ -160,7 +160,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
         $levelId = new LevelId('00000000-0000-0000-0000-000000000003');
         $level = new Level($levelId, 'test', 10);
 
-        $commandBus = $this->getMock(CommandBusInterface::class);
+        $commandBus = $this->getMockBuilder(CommandBusInterface::class)->getMock();
         $commandBus->expects($this->once())->method('dispatch')->with(
             $this->equalTo(
                 new MoveCustomerToLevel(
@@ -189,7 +189,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function getTierTypeAssignProvider($type)
     {
-        $mock = $this->getMock(TierAssignTypeProvider::class);
+        $mock = $this->getMockBuilder(TierAssignTypeProvider::class)->getMock();
         $mock->method('getType')->willReturn($type);
 
         return $mock;
@@ -197,7 +197,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function getCustomerDetailsRepository(CustomerLevelId $currentLevelId = null, CustomerLevelId $assignedLevelId = null)
     {
-        $repo = $this->getMock(CustomerDetailsRepository::class);
+        $repo = $this->getMockBuilder(CustomerDetailsRepository::class)->getMock();
         $repo->method('find')->with($this->isType('string'))->willReturnCallback(function($id) use ($currentLevelId, $assignedLevelId) {
             $customer = $this->getMockBuilder(CustomerDetails::class);
             $customer->disableOriginalConstructor();
@@ -217,7 +217,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
         if (!is_array($levels)) {
             $levels = [$levels];
         }
-        $repo = $this->getMock(LevelIdProvider::class);
+        $repo = $this->getMockBuilder(LevelIdProvider::class)->getMock();
         $repo->method('findLevelIdByConditionValueWithTheBiggestReward')
             ->with($this->greaterThanOrEqual(0))
             ->will($this->returnCallback(function ($conditionValue) use ($levels) {
@@ -247,7 +247,7 @@ class CalculateCustomerLevelListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function getExcludeDeliveryCostsProvider($returnValue)
     {
-        $mock = $this->getMock(ExcludeDeliveryCostsProvider::class);
+        $mock = $this->getMockBuilder(ExcludeDeliveryCostsProvider::class)->getMock();
         $mock->method('areExcluded')->willReturn($returnValue);
 
         return $mock;


### PR DESCRIPTION
Class constructor requires three arguments instead of four passed by service configuration. I've removed unnecessary argument as EmailSettingsBundle is responsible for injecting email message from the database.

At the same time, I've fixed deprecation warnings, removed unused imports, variables and fixed some typos in the unit tests.